### PR TITLE
fix: retry partial block fetch chunks

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -32,15 +32,14 @@ type startCfg struct {
 	remote        string
 	dbPath        string
 	logLevel      string
+	genesisURL    string
 
-	maxSlots     int
 	maxChunkSize int64
-
-	rateLimit int
+	maxSlots     int
+	rateLimit    int
 
 	disableIntrospection bool
 	clearOnReset         bool
-	genesisURL           string
 }
 
 // newStartCmd creates the indexer start command

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -264,6 +264,12 @@ func (f *Fetcher) FetchChainData(ctx context.Context) error {
 					"error encountered during chunk fetch",
 					zap.String("error", response.error.Error()),
 				)
+
+				if !hasCompleteBlockRange(response.chunk, response.chunkRange) {
+					f.chunkBuffer.removeSlot(index)
+
+					continue
+				}
 			}
 
 			// Save the chunk
@@ -290,6 +296,10 @@ func (f *Fetcher) FetchChainData(ctx context.Context) error {
 }
 
 func (f *Fetcher) writeSlot(s *slot) error {
+	if err := validateSlot(s); err != nil {
+		return err
+	}
+
 	wb := f.storage.WriteBatch()
 
 	// Save the fetched data
@@ -355,6 +365,54 @@ func (f *Fetcher) writeSlot(s *slot) error {
 	f.latestChunkSize = len(s.chunk.blocks)
 
 	return nil
+}
+
+func validateSlot(s *slot) error {
+	if s == nil || s.chunk == nil {
+		return errors.New("empty slot")
+	}
+
+	if !hasCompleteBlockRange(s.chunk, s.chunkRange) {
+		return fmt.Errorf(
+			"partial block chunk for range [%d,%d]: expected %d blocks, got %d",
+			s.chunkRange.from,
+			s.chunkRange.to,
+			int(s.chunkRange.to-s.chunkRange.from+1),
+			len(s.chunk.blocks),
+		)
+	}
+
+	if len(s.chunk.results) != len(s.chunk.blocks) {
+		return fmt.Errorf(
+			"partial tx result chunk for range [%d,%d]: expected %d result sets, got %d",
+			s.chunkRange.from,
+			s.chunkRange.to,
+			len(s.chunk.blocks),
+			len(s.chunk.results),
+		)
+	}
+
+	return nil
+}
+
+func hasCompleteBlockRange(c *chunk, r chunkRange) bool {
+	if c == nil {
+		return false
+	}
+
+	expectedBlockCount := int(r.to - r.from + 1)
+	if len(c.blocks) != expectedBlockCount {
+		return false
+	}
+
+	for index, block := range c.blocks {
+		expectedHeight := int64(r.from) + int64(index)
+		if block == nil || block.Height != expectedHeight {
+			return false
+		}
+	}
+
+	return true
 }
 
 func (f *Fetcher) IsReady(ctx context.Context) (bool, error) {

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -45,6 +45,7 @@ type Fetcher struct {
 	maxSlots        int
 	maxChunkSize    int64
 	latestChunkSize int
+	gapScanHeight   uint64
 	queryInterval   time.Duration // block query interval
 	clearOnReset    bool
 }
@@ -182,12 +183,6 @@ func (f *Fetcher) FetchChainData(ctx context.Context) error {
 			return nil
 		}
 
-		// Check if there is a block gap
-		if latestRemote == latestLocal {
-			// No gap, nothing to sync
-			return nil
-		}
-
 		// Check if there is reset chains
 		if latestRemote < latestLocal {
 			if f.clearOnReset {
@@ -201,11 +196,32 @@ func (f *Fetcher) FetchChainData(ctx context.Context) error {
 			return nil
 		}
 
-		gaps := f.chunkBuffer.reserveChunkRanges(
-			latestLocal+1,
-			latestRemote,
-			f.maxChunkSize,
-		)
+		gaps := make([]chunkRange, 0, f.maxSlots)
+		if latestRemote == latestLocal {
+			localGap, hasLocalGap, err := f.findMissingLocalBlockRange(latestLocal)
+			if err != nil {
+				return err
+			}
+
+			if !hasLocalGap {
+				// No gap, nothing to sync
+				return nil
+			}
+
+			gaps = append(gaps, f.chunkBuffer.reserveChunkRanges(
+				localGap.from,
+				localGap.to,
+				f.maxChunkSize,
+			)...)
+		}
+
+		if latestRemote > latestLocal {
+			gaps = append(gaps, f.chunkBuffer.reserveChunkRanges(
+				latestLocal+1,
+				latestRemote,
+				f.maxChunkSize,
+			)...)
+		}
 
 		for _, gap := range gaps {
 			f.logger.Info(
@@ -239,7 +255,6 @@ func (f *Fetcher) FetchChainData(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			f.logger.Info("Fetcher service shut down")
-			close(collectorCh)
 
 			return nil
 		case <-ticker.C:
@@ -261,12 +276,17 @@ func (f *Fetcher) FetchChainData(ctx context.Context) error {
 					"error encountered during chunk fetch",
 					zap.String("error", response.error.Error()),
 				)
+			}
 
-				if !hasCompleteBlockRange(response.chunk, response.chunkRange) {
-					f.chunkBuffer.removeSlot(index)
+			responseSlot := &slot{
+				chunk:      response.chunk,
+				chunkRange: response.chunkRange,
+			}
+			if err := validateSlot(responseSlot); err != nil {
+				f.logger.Warn("discarding incomplete chunk", zap.Error(err))
+				f.chunkBuffer.removeSlot(index)
 
-					continue
-				}
+				continue
 			}
 
 			// Save the chunk
@@ -346,8 +366,7 @@ func (f *Fetcher) writeSlot(s *slot) error {
 		zap.Uint64("to", s.chunkRange.to),
 	)
 
-	// Save the latest height data
-	if err := wb.SetLatestHeight(s.chunkRange.to); err != nil {
+	if err := f.setLatestHeight(wb, s.chunkRange.to); err != nil {
 		if rErr := wb.Rollback(); rErr != nil {
 			return fmt.Errorf("unable to save latest height info, %w, %w", err, rErr)
 		}
@@ -362,6 +381,70 @@ func (f *Fetcher) writeSlot(s *slot) error {
 	f.latestChunkSize = len(s.chunk.blocks)
 
 	return nil
+}
+
+func (f *Fetcher) setLatestHeight(wb storage.Batch, height uint64) error {
+	latest, err := f.storage.GetLatestHeight()
+	if err != nil && !errors.Is(err, storageErrors.ErrNotFound) {
+		return fmt.Errorf("unable to fetch latest block height, %w", err)
+	}
+
+	if err == nil && latest > height {
+		return nil
+	}
+
+	return wb.SetLatestHeight(height)
+}
+
+func (f *Fetcher) findMissingLocalBlockRange(latestLocal uint64) (chunkRange, bool, error) {
+	if latestLocal == 0 {
+		return chunkRange{}, false, nil
+	}
+
+	if f.gapScanHeight == 0 {
+		f.gapScanHeight = 1
+	}
+
+	if f.gapScanHeight > latestLocal {
+		return chunkRange{}, false, nil
+	}
+
+	maxScanSize := uint64(f.maxChunkSize)
+	if maxScanSize == 0 {
+		maxScanSize = 1
+	}
+
+	start := f.gapScanHeight
+	end := min(latestLocal, start+maxScanSize-1)
+
+	for height := start; height <= end; height++ {
+		if _, err := f.storage.GetBlock(height); err == nil {
+			continue
+		} else if !errors.Is(err, storageErrors.ErrNotFound) {
+			return chunkRange{}, false, fmt.Errorf("unable to check local block %d, %w", height, err)
+		}
+
+		gap := chunkRange{
+			from: height,
+			to:   height,
+		}
+
+		for next := height + 1; next <= end; next++ {
+			if _, err := f.storage.GetBlock(next); err == nil {
+				break
+			} else if !errors.Is(err, storageErrors.ErrNotFound) {
+				return chunkRange{}, false, fmt.Errorf("unable to check local block %d, %w", next, err)
+			}
+
+			gap.to = next
+		}
+
+		return gap, true, nil
+	}
+
+	f.gapScanHeight = end + 1
+
+	return chunkRange{}, false, nil
 }
 
 func validateSlot(s *slot) error {
@@ -387,6 +470,31 @@ func validateSlot(s *slot) error {
 			len(s.chunk.blocks),
 			len(s.chunk.results),
 		)
+	}
+
+	for blockIndex, block := range s.chunk.blocks {
+		expectedTxCount := int(block.NumTxs)
+		if block.NumTxs < 0 {
+			return fmt.Errorf("invalid tx count for block %d: %d", block.Height, block.NumTxs)
+		}
+
+		if len(block.Txs) != expectedTxCount {
+			return fmt.Errorf(
+				"partial tx chunk for block %d: expected %d txs, got %d",
+				block.Height,
+				expectedTxCount,
+				len(block.Txs),
+			)
+		}
+
+		if len(s.chunk.results[blockIndex]) != expectedTxCount {
+			return fmt.Errorf(
+				"partial tx result chunk for block %d: expected %d tx results, got %d",
+				block.Height,
+				expectedTxCount,
+				len(s.chunk.results[blockIndex]),
+			)
+		}
 	}
 
 	return nil

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -35,22 +35,18 @@ var errInvalidGenesisState = errors.New("invalid genesis state")
 // Fetcher is an instance of the block indexer
 // fetcher
 type Fetcher struct {
-	storage storage.Storage
-	client  Client
-	events  Events
-
-	logger      *zap.Logger
-	chunkBuffer *slots
-
+	storage         storage.Storage
+	client          Client
+	events          Events
+	logger          *zap.Logger
+	chunkBuffer     *slots
+	dbPath          string
+	genesisURL      string
 	maxSlots        int
 	maxChunkSize    int64
 	latestChunkSize int
-
-	queryInterval time.Duration // block query interval
-
-	dbPath       string
-	clearOnReset bool
-	genesisURL   string // optional URL to download genesis.json as fallback
+	queryInterval   time.Duration // block query interval
+	clearOnReset    bool
 }
 
 // New creates a new data fetcher instance
@@ -95,6 +91,7 @@ func (f *Fetcher) fetchGenesisData(ctx context.Context) error {
 	}
 
 	f.logger.Info("Fetching genesis")
+
 	block, err := getGenesisBlock(ctx, f.client)
 	if err != nil {
 		f.logger.Warn("RPC genesis fetch failed", zap.Error(err))
@@ -475,14 +472,18 @@ func (f *Fetcher) getGenesisBlockFromURL(ctx context.Context) (*bft_types.Block,
 	if err != nil {
 		return nil, fmt.Errorf("unable to create temp file: %w", err)
 	}
+
 	tmpPath := tmpFile.Name()
 	defer os.Remove(tmpPath)
 
 	// Download to temp file
-	if err := f.downloadGenesis(ctx, tmpFile); err != nil {
+	err = f.downloadGenesis(ctx, tmpFile)
+	if err != nil {
 		tmpFile.Close()
+
 		return nil, fmt.Errorf("unable to download genesis.json: %w", err)
 	}
+
 	tmpFile.Close()
 
 	data, err := os.ReadFile(tmpPath)
@@ -504,7 +505,9 @@ func (f *Fetcher) getGenesisBlockFromURL(ctx context.Context) (*bft_types.Block,
 	}
 
 	var genDoc bft_types.GenesisDoc
-	if err := amino.UnmarshalJSON(data, &genDoc); err != nil {
+
+	err = amino.UnmarshalJSON(data, &genDoc)
+	if err != nil {
 		return nil, fmt.Errorf("unable to parse genesis.json: %w", err)
 	}
 
@@ -539,7 +542,7 @@ func (f *Fetcher) getGenesisBlockFromURL(ctx context.Context) (*bft_types.Block,
 // downloadGenesis downloads the genesis file from the configured URL,
 // streaming directly to the provided file to handle large payloads.
 func (f *Fetcher) downloadGenesis(ctx context.Context, dest *os.File) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, f.genesisURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, f.genesisURL, http.NoBody)
 	if err != nil {
 		return fmt.Errorf("unable to create request: %w", err)
 	}
@@ -599,6 +602,7 @@ func sanitizeGenesisTxMetadata(data []byte) ([]byte, error) {
 	known := knownJSONFields(reflect.TypeOf(gnoland.GnoTxMetadata{}))
 
 	changed := false
+
 	for _, tx := range txs {
 		metaRaw, ok := tx["metadata"]
 		if !ok {
@@ -613,6 +617,7 @@ func sanitizeGenesisTxMetadata(data []byte) ([]byte, error) {
 		for key := range meta {
 			if !known[key] {
 				delete(meta, key)
+
 				changed = true
 			}
 		}
@@ -635,12 +640,14 @@ func sanitizeGenesisTxMetadata(data []byte) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to re-encode genesis txs: %w", err)
 	}
+
 	appState["txs"] = newTxs
 
 	newAppState, err := json.Marshal(appState)
 	if err != nil {
 		return nil, fmt.Errorf("unable to re-encode app_state: %w", err)
 	}
+
 	doc["app_state"] = newAppState
 
 	return json.Marshal(doc)
@@ -654,10 +661,12 @@ func knownJSONFields(t reflect.Type) map[string]bool {
 	fields := make(map[string]bool, t.NumField())
 	for i := 0; i < t.NumField(); i++ {
 		tag := t.Field(i).Tag.Get("json")
+
 		name := strings.Split(tag, ",")[0]
 		if name == "" || name == "-" {
 			name = t.Field(i).Name
 		}
+
 		fields[name] = true
 	}
 

--- a/fetch/fetch_test.go
+++ b/fetch/fetch_test.go
@@ -929,6 +929,9 @@ func TestFetcher_InvalidBlocks(t *testing.T) {
 		txs      = generateTransactions(t, txCount)
 		blocks   = generateBlocks(t, blockNum+1, txs)
 
+		attemptsMu     sync.Mutex
+		resultAttempts = map[uint64]int{}
+
 		savedBlocks    = make([]*types.Block, 0, blockNum)
 		capturedEvents = make([]*indexerTypes.NewBlock, 0)
 
@@ -1004,6 +1007,15 @@ func TestFetcher_InvalidBlocks(t *testing.T) {
 
 				require.LessOrEqual(t, num, uint64(blockNum))
 
+				attemptsMu.Lock()
+
+				resultAttempts[num]++
+				if num == 1 && resultAttempts[num] == 2 {
+					cancelFn()
+				}
+
+				attemptsMu.Unlock()
+
 				return nil, fmt.Errorf("unable to fetch result for block %d", num)
 			},
 			getGenesisFn: func() (*core_types.ResultGenesis, error) {
@@ -1029,10 +1041,16 @@ func TestFetcher_InvalidBlocks(t *testing.T) {
 	// Run the fetch
 	require.NoError(t, f.FetchChainData(ctx))
 
-	// Make sure correct blocks were attempted to be saved
-	for blockIndex := 1; blockIndex < blockNum; blockIndex++ {
-		assert.Equal(t, blocks[blockIndex], savedBlocks[blockIndex])
-	}
+	require.Len(t, savedBlocks, 1)
+	assert.EqualValues(t, 0, savedBlocks[0].Height)
+
+	attemptsMu.Lock()
+
+	blockOneAttempts := resultAttempts[1]
+
+	attemptsMu.Unlock()
+
+	assert.GreaterOrEqual(t, blockOneAttempts, 2)
 
 	// Make sure no events were emitted
 	assert.Len(t, capturedEvents, 0)
@@ -1136,6 +1154,226 @@ func TestFetcher_RetriesPartialBlockFetch(t *testing.T) {
 	attemptsMu.Unlock()
 
 	require.Equal(t, 2, blockThreeAttempts)
+}
+
+func TestFetcher_RetriesPartialTxResults(t *testing.T) {
+	t.Parallel()
+
+	var (
+		blockNum = 5
+		txs      = generateTransactions(t, 1)
+		blocks   = generateBlocks(t, blockNum+1, txs)
+
+		attemptsMu     sync.Mutex
+		resultAttempts = map[uint64]int{}
+
+		savedBlocks = make([]*types.Block, 0, blockNum)
+		savedTxs    = make([]*types.TxResult, 0, blockNum)
+		latestSaved = uint64(0)
+
+		mockEvents = &mockEvents{}
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	mockStorage := &mock.Storage{
+		GetLatestSavedHeightFn: func() (uint64, error) {
+			return latestSaved, nil
+		},
+		GetWriteBatchFn: func() storage.Batch {
+			return &mock.WriteBatch{
+				SetBlockFn: func(block *types.Block) error {
+					savedBlocks = append(savedBlocks, block)
+
+					return nil
+				},
+				SetTxFn: func(result *types.TxResult) error {
+					savedTxs = append(savedTxs, result)
+
+					return nil
+				},
+				SetLatestHeightFn: func(height uint64) error {
+					latestSaved = height
+					if height == uint64(blockNum) {
+						cancel()
+					}
+
+					return nil
+				},
+			}
+		},
+	}
+
+	mockClient := &mockClient{
+		createBatchFn: func() clientTypes.Batch {
+			return &mockBatch{
+				executeFn: func(_ context.Context) ([]any, error) {
+					return nil, errors.New("batch unavailable")
+				},
+				countFn: func() int {
+					return 1
+				},
+			}
+		},
+		getLatestBlockNumberFn: func() (uint64, error) {
+			return uint64(blockNum), nil
+		},
+		getBlockFn: func(num uint64) (*core_types.ResultBlock, error) {
+			return &core_types.ResultBlock{
+				Block: blocks[num],
+			}, nil
+		},
+		getBlockResultsFn: func(num uint64) (*core_types.ResultBlockResults, error) {
+			attemptsMu.Lock()
+
+			resultAttempts[num]++
+			currentAttempt := resultAttempts[num]
+
+			attemptsMu.Unlock()
+
+			deliverTxs := make([]abci.ResponseDeliverTx, len(txs))
+			if num == 3 && currentAttempt == 1 {
+				deliverTxs = make([]abci.ResponseDeliverTx, 0)
+			}
+
+			return &core_types.ResultBlockResults{
+				Height: int64(num),
+				Results: &state.ABCIResponses{
+					DeliverTxs: deliverTxs,
+				},
+			}, nil
+		},
+	}
+
+	f := New(
+		mockStorage,
+		mockClient,
+		mockEvents,
+		WithMaxSlots(1),
+		WithMaxChunkSize(int64(blockNum)),
+	)
+	f.queryInterval = time.Millisecond
+
+	require.NoError(t, f.FetchChainData(ctx))
+	require.Equal(t, uint64(blockNum), latestSaved)
+	require.Len(t, savedBlocks, blockNum)
+	require.Len(t, savedTxs, blockNum)
+
+	attemptsMu.Lock()
+
+	blockThreeAttempts := resultAttempts[3]
+
+	attemptsMu.Unlock()
+
+	require.Equal(t, 2, blockThreeAttempts)
+}
+
+func TestFetcher_RecoversMissingLocalBlock_whenLatestAlreadyAdvanced(t *testing.T) {
+	t.Parallel()
+
+	var (
+		blockNum = 5
+		blocks   = generateBlocks(t, blockNum+1, []*std.Tx{})
+
+		localMu     sync.Mutex
+		localBlocks = map[uint64]*types.Block{
+			1: blocks[1],
+			2: blocks[2],
+			4: blocks[4],
+			5: blocks[5],
+		}
+
+		remoteAttempts = map[uint64]int{}
+		latestSaved    = uint64(blockNum)
+		latestWrites   = make([]uint64, 0)
+
+		mockEvents = &mockEvents{}
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	mockStorage := &mock.Storage{
+		GetLatestSavedHeightFn: func() (uint64, error) {
+			return latestSaved, nil
+		},
+		GetBlockFn: func(height uint64) (*types.Block, error) {
+			localMu.Lock()
+			defer localMu.Unlock()
+
+			block, ok := localBlocks[height]
+			if !ok {
+				return nil, storageErrors.ErrNotFound
+			}
+
+			return block, nil
+		},
+		GetWriteBatchFn: func() storage.Batch {
+			return &mock.WriteBatch{
+				SetBlockFn: func(block *types.Block) error {
+					localMu.Lock()
+					localBlocks[uint64(block.Height)] = block
+					localMu.Unlock()
+
+					if block.Height == 3 {
+						cancel()
+					}
+
+					return nil
+				},
+				SetLatestHeightFn: func(height uint64) error {
+					latestWrites = append(latestWrites, height)
+					latestSaved = height
+
+					return nil
+				},
+			}
+		},
+	}
+
+	mockClient := &mockClient{
+		createBatchFn: func() clientTypes.Batch {
+			return &mockBatch{
+				executeFn: func(_ context.Context) ([]any, error) {
+					return nil, errors.New("batch unavailable")
+				},
+				countFn: func() int {
+					return 1
+				},
+			}
+		},
+		getLatestBlockNumberFn: func() (uint64, error) {
+			return uint64(blockNum), nil
+		},
+		getBlockFn: func(num uint64) (*core_types.ResultBlock, error) {
+			remoteAttempts[num]++
+
+			return &core_types.ResultBlock{
+				Block: blocks[num],
+			}, nil
+		},
+	}
+
+	f := New(
+		mockStorage,
+		mockClient,
+		mockEvents,
+		WithMaxSlots(1),
+		WithMaxChunkSize(int64(blockNum)),
+	)
+	f.queryInterval = time.Millisecond
+
+	require.NoError(t, f.FetchChainData(ctx))
+
+	localMu.Lock()
+	recoveredBlock := localBlocks[3]
+	localMu.Unlock()
+
+	require.Equal(t, blocks[3], recoveredBlock)
+	require.Equal(t, 1, remoteAttempts[3])
+	require.Empty(t, latestWrites)
+	require.Equal(t, uint64(blockNum), latestSaved)
 }
 
 func TestFetcher_Genesis(t *testing.T) {

--- a/fetch/fetch_test.go
+++ b/fetch/fetch_test.go
@@ -1096,8 +1096,10 @@ func TestFetcher_RetriesPartialBlockFetch(t *testing.T) {
 		},
 		getBlockFn: func(num uint64) (*core_types.ResultBlock, error) {
 			attemptsMu.Lock()
+
 			attempts[num]++
 			currentAttempt := attempts[num]
+
 			attemptsMu.Unlock()
 
 			if num == 3 && currentAttempt == 1 {
@@ -1128,7 +1130,9 @@ func TestFetcher_RetriesPartialBlockFetch(t *testing.T) {
 	}
 
 	attemptsMu.Lock()
+
 	blockThreeAttempts := attempts[3]
+
 	attemptsMu.Unlock()
 
 	require.Equal(t, 2, blockThreeAttempts)

--- a/fetch/fetch_test.go
+++ b/fetch/fetch_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -1035,6 +1036,102 @@ func TestFetcher_InvalidBlocks(t *testing.T) {
 
 	// Make sure no events were emitted
 	assert.Len(t, capturedEvents, 0)
+}
+
+func TestFetcher_RetriesPartialBlockFetch(t *testing.T) {
+	t.Parallel()
+
+	var (
+		blockNum = 5
+		blocks   = generateBlocks(t, blockNum+1, []*std.Tx{})
+
+		attemptsMu sync.Mutex
+		attempts   = map[uint64]int{}
+
+		savedBlocks = make([]*types.Block, 0, blockNum)
+		latestSaved = uint64(0)
+
+		mockEvents = &mockEvents{}
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	mockStorage := &mock.Storage{
+		GetLatestSavedHeightFn: func() (uint64, error) {
+			return latestSaved, nil
+		},
+		GetWriteBatchFn: func() storage.Batch {
+			return &mock.WriteBatch{
+				SetBlockFn: func(block *types.Block) error {
+					savedBlocks = append(savedBlocks, block)
+
+					return nil
+				},
+				SetLatestHeightFn: func(height uint64) error {
+					latestSaved = height
+					if height == uint64(blockNum) {
+						cancel()
+					}
+
+					return nil
+				},
+			}
+		},
+	}
+
+	mockClient := &mockClient{
+		createBatchFn: func() clientTypes.Batch {
+			return &mockBatch{
+				executeFn: func(_ context.Context) ([]any, error) {
+					return nil, errors.New("batch unavailable")
+				},
+				countFn: func() int {
+					return 1
+				},
+			}
+		},
+		getLatestBlockNumberFn: func() (uint64, error) {
+			return uint64(blockNum), nil
+		},
+		getBlockFn: func(num uint64) (*core_types.ResultBlock, error) {
+			attemptsMu.Lock()
+			attempts[num]++
+			currentAttempt := attempts[num]
+			attemptsMu.Unlock()
+
+			if num == 3 && currentAttempt == 1 {
+				return nil, errors.New("temporary block fetch error")
+			}
+
+			return &core_types.ResultBlock{
+				Block: blocks[num],
+			}, nil
+		},
+	}
+
+	f := New(
+		mockStorage,
+		mockClient,
+		mockEvents,
+		WithMaxSlots(1),
+		WithMaxChunkSize(int64(blockNum)),
+	)
+	f.queryInterval = time.Millisecond
+
+	require.NoError(t, f.FetchChainData(ctx))
+	require.Equal(t, uint64(blockNum), latestSaved)
+	require.Len(t, savedBlocks, blockNum)
+
+	for index, block := range savedBlocks {
+		require.EqualValues(t, index+1, block.Height)
+	}
+
+	attemptsMu.Lock()
+	blockThreeAttempts := attempts[3]
+	attemptsMu.Unlock()
+
+	require.Equal(t, 2, blockThreeAttempts)
 }
 
 func TestFetcher_Genesis(t *testing.T) {

--- a/fetch/slots.go
+++ b/fetch/slots.go
@@ -60,6 +60,17 @@ func (s *slots) setChunk(index int, chunk *chunk) {
 	s.Queue[index] = item
 }
 
+func (s *slots) removeSlot(index int) *slot {
+	item := s.getSlot(index)
+	if item == nil {
+		return nil
+	}
+
+	s.Queue = append(s.Queue[:index], s.Queue[index+1:]...)
+
+	return item
+}
+
 // reserveChunkRanges reserves empty chunk ranges, and returns them, if any
 func (s *slots) reserveChunkRanges(start, end uint64, maxChunkSize int64) []chunkRange {
 	freeSlots := s.maxSlots - s.Len()

--- a/fetch/worker.go
+++ b/fetch/worker.go
@@ -175,8 +175,25 @@ func getTxResultFromBatch(ctx context.Context, blocks []*types.Block, client Cli
 		}
 
 		height := results.Height
+		blockIndex, ok := indexOfBlockHeight[height]
+		if !ok {
+			return fetchedResults, fmt.Errorf("unexpected tx results for block %d", height)
+		}
+
+		if results.Results == nil {
+			return fetchedResults, fmt.Errorf("nil tx results for block %d", height)
+		}
+
+		block := blocks[blockIndex]
 		deliverTxs := results.Results.DeliverTxs
-		blockIndex := indexOfBlockHeight[height]
+		if len(deliverTxs) != int(block.NumTxs) {
+			return fetchedResults, fmt.Errorf(
+				"partial tx results for block %d: expected %d, got %d",
+				height,
+				block.NumTxs,
+				len(deliverTxs),
+			)
+		}
 
 		txResults := make([]*types.TxResult, blocks[blockIndex].NumTxs)
 
@@ -225,6 +242,27 @@ func getTxResultsSequentially(ctx context.Context, blocks []*types.Block, client
 		}
 
 		// Save the transaction result
+		if blockResults.Results == nil {
+			errs = append(errs, fmt.Errorf("nil tx results for block %d", block.Height))
+
+			continue
+		}
+
+		deliverTxs := blockResults.Results.DeliverTxs
+		if len(deliverTxs) != int(block.NumTxs) {
+			errs = append(
+				errs,
+				fmt.Errorf(
+					"partial tx results for block %d: expected %d, got %d",
+					block.Height,
+					block.NumTxs,
+					len(deliverTxs),
+				),
+			)
+
+			continue
+		}
+
 		txResults := make([]*types.TxResult, block.NumTxs)
 
 		for index, tx := range block.Txs {
@@ -232,7 +270,7 @@ func getTxResultsSequentially(ctx context.Context, blocks []*types.Block, client
 				Height:   block.Height,
 				Index:    uint32(index),
 				Tx:       tx,
-				Response: blockResults.Results.DeliverTxs[index],
+				Response: deliverTxs[index],
 			}
 
 			txResults[index] = result

--- a/serve/conns/wsconn/ws_conns.go
+++ b/serve/conns/wsconn/ws_conns.go
@@ -33,7 +33,6 @@ func (pw *Conns) AddWSConnection(id string, session *melody.Session) {
 	pw.mux.Lock()
 	defer pw.mux.Unlock()
 
-	//nolint:gosec // G118: cancelFn is called in RemoveWSConnection
 	ctx, cancelFn := context.WithCancel(context.Background())
 
 	pw.conns[id] = Conn{

--- a/serve/conns/wsconn/ws_conns.go
+++ b/serve/conns/wsconn/ws_conns.go
@@ -33,6 +33,7 @@ func (pw *Conns) AddWSConnection(id string, session *melody.Session) {
 	pw.mux.Lock()
 	defer pw.mux.Unlock()
 
+	//nolint:gosec,nolintlint // G118 false positive: cancelFn is stored and called in RemoveWSConnection.
 	ctx, cancelFn := context.WithCancel(context.Background())
 
 	pw.conns[id] = Conn{


### PR DESCRIPTION
## Summary
- Prevent partially fetched block chunks from being committed as complete ranges.
- Release the reserved chunk slot when a block range is incomplete so the same range can be retried.
- Add a regression test for a temporary missing block during chunk fetch.

## Context
- Downstream block sync expects contiguous block ranges from tx-indexer.
- If tx-indexer advances the latest height after saving an incomplete chunk, later consumers can observe missing block heights inside an otherwise processed range.

## Changes
- Validate block chunk completeness before writing a slot.
- Skip committing errored chunk responses only when the block range is incomplete, while preserving existing soft handling for tx result errors.
- Add slot removal support so failed partial ranges can be reserved again on the next fetch loop.

## Verification
- `go test ./fetch -run 'TestFetcher_RetriesPartialBlockFetch|TestFetcher_InvalidBlocks' -count=1 -v`\n- `go test ./fetch -count=1`\n- `go test ./... -count=1`\n\n## Deployment Notes\n- No Helm or schema changes are required.\n- Deploying this change only affects tx-indexer fetch behavior for incomplete block chunks.\n\n## Rollback\n- Revert this PR to restore the previous behavior.